### PR TITLE
feat: break up module 2-5 into smaller chunks

### DIFF
--- a/content/02_module/10-Sign up with Lumigo.md
+++ b/content/02_module/10-Sign up with Lumigo.md
@@ -1,0 +1,31 @@
++++
+title = "2.1 Sign up with Lumigo"
+chapter = true
+weight = 10
++++
+
+## Sign up with Lumigo
+
+To get started with Lumigo, take the following steps. A more detailed guide can be found at [the Lumigo documentation](https://docs.lumigo.io/docs/create-an-account).
+
+1. Head over to https://platform.lumigo.io/signup and sign up for an account
+
+2. Once you created your account, Lumigo will guide you through the integration. First, fill in some details.
+
+![Lumigo about you](/images/mod02-lumigo-about-you.png)
+
+3. Next, we will link Lumigo to our AWS account. To do so all that is required is to deploy its CloudFormation stack to your account. A more detailed walkthrough of this step can be found [here](https://docs.lumigo.io/docs/connect-your-environment)
+
+![Lumigo connect AWS](/images/mod02-lumigo-connect-aws.png)
+
+4. You should land at the instrumentation step, which will let us choose functions to trace:
+
+![Lumigo auto instrumentation](/images/mod02-lumigo-auto-instrumentation.png)
+
+You can also do this after the initial setup too. Just head over to the [Functions](https://platform.lumigo.io/functions) page at any time, and you can auto-trace any function there:
+
+![Lumigo auto trace](/images/mod02-lumigo-auto-trace.png)
+
+Once you added tracing to the relevant Lambda functions, Lumigo will automatically start monitoring your application.
+
+5. Order some unicorn rides, and let's see what's going on in Lumigo!

--- a/content/02_module/20-View your application in Lumigo.md
+++ b/content/02_module/20-View your application in Lumigo.md
@@ -1,35 +1,8 @@
----
-title: "Serverless observability"
-chapter: true
-weight: 11
----
-
-## Integrate Lumigo into the app
-
-To get started with Lumigo, take the following steps. A more detailed guide can be found at [the Lumigo documentation](https://docs.lumigo.io/docs/create-an-account).
-
-1. Head over to https://platform.lumigo.io/signup and sign up for an account
-
-2. Once you created your account, Lumigo will guide you through the integration. First, fill in some details.
-
-![Lumigo about you](/images/mod02-lumigo-about-you.png)
-
-3. Next, we will link Lumigo to our AWS account. To do so all that is required is to deploy its CloudFormation stack to your account. A more detailed walkthrough of this step can be found [here](https://docs.lumigo.io/docs/connect-your-environment)
-
-![Lumigo connect AWS](/images/mod02-lumigo-connect-aws.png)
-
-4. You should land at the instrumentation step, which will let us choose functions to trace:
-
-![Lumigo auto instrumentation](/images/mod02-lumigo-auto-instrumentation.png)
-
-You can also do this after the initial setup too. Just head over to the [Functions](https://platform.lumigo.io/functions) page at any time, and you can auto-trace any function there:
-
-![Lumigo auto trace](/images/mod02-lumigo-auto-trace.png)
-
-Once you added tracing to the relevant Lambda functions, Lumigo will automatically start monitoring your application.
-
-5. Order some unicorn rides, and let's see what's going on in Lumigo!
-
++++
+title = "2.2 View your application Lumigo"
+chapter = true
+weight = 20
++++
 
 ## Viewing your application in Lumigo
 

--- a/content/02_module/_index.md
+++ b/content/02_module/_index.md
@@ -1,9 +1,11 @@
 +++
 title = "Module 2"
 chapter = true
-weight = 11
+weight = 20
 +++
 
 # Module 2 - Serverless Observability
 
 In this module, you will integrate [Lumigo](https://lumigo.io) with the demo application.
+
+{{% children showhidden="false" %}}

--- a/content/03_module/10-Troubleshoot timeouts (sync functions).md
+++ b/content/03_module/10-Troubleshoot timeouts (sync functions).md
@@ -1,0 +1,27 @@
++++
+title = "3.1 Troubleshoot timeouts (synchronous functions)"
+chapter = true
+weight = 10
++++
+
+## Troubleshoot timeouts (synchronous functions)
+
+Let's see how we can use Lumigo to troubleshoot timeouts for synchronous Lambda functions such as those handling API requests.
+
+1. If you click on the `Timeout` issue for the `requestUnicorn` function, it will take you to the function details page for the function and show you the invocations that timed out.
+
+![requestUnicorn timeouts](/images/mod03-lumigo-requestUnicorn-timeouts.png)
+
+2. Click on one of the timed out transactions to see what happened in that transaction.
+
+![requestUnicorn timed out](/images/mod03-lumigo-requestUnicorn-timeout-transaction.png)
+
+3. From the function logs, you can see a message like `2020-10-20T11:40:37.402Z	3ea3b770-2986-4926-a0b3-2c6a045bfa20	INFO	Finding unicorn for  42.34963749150315 ,  -71.05718295574066`
+
+and then 6 seconds later, the invocation timed out.
+
+![requestUnicorn timed out](/images/mod03-lumigo-requestUnicorn-timeout-transaction-log.png)
+
+4. Click on the `Timeline` tab and you will see that the request to `4fsay0n12a.execute-api.us-east-1.amazonaws.com` never completed, hence the `N/A`. So this was the cause for the invocation timing out.
+
+![requestUnicorn timed out](/images/mod03-lumigo-requestUnicorn-timeout-transaction-timeline.png)

--- a/content/03_module/20-Troubleshoot timeouts (async functions).md
+++ b/content/03_module/20-Troubleshoot timeouts (async functions).md
@@ -1,0 +1,23 @@
++++
+title = "3.2 Troubleshoot timeouts (asynchronous functions)"
+chapter = true
+weight = 20
++++
+
+## Troubleshoot timeouts (asynchronous functions)
+
+Asynchronous Lambda functions (such as those handling background tasks via SNS topics, EventBridge buses or SQS queues) are often tricky to debug because their failures are silent. These failures can go unnoticed for months or even years! The problems they cause would often manifest in unpredictable ways that makes it difficult to trace the symptoms to the original errors.
+
+So let's take a moment to see how we can troubleshoot timeouts for these asynchronous Lambda functions.
+
+1. Go to back the [Issues & Alerts](https://platform.lumigo.io/issues) page and you'll see that the `calcSalaries` function has also timed out a few times. As before, click on the `Timeout` issue for `calcSalaries` and see the timed out invocations.
+
+![calcSalaries timeouts](/images/mod03-lumigo-calcSalaries-timeouts.png)
+
+2. Click on one of the timed out transactions to see what happened.
+
+![calcSalaries timed out](/images/mod03-lumigo-calcSalaries-timeout-transaction.png)
+
+3. Unfortunately, there's nothing in the logs to indicate what happened. But let's click on `Timeline` tab to see what happened.
+
+![requestUnicorn timed out](/images/mod03-lumigo-requestUnicorn-timeout-transaction-timeline.png)

--- a/content/03_module/30-Troubleshoot business logic errors.md
+++ b/content/03_module/30-Troubleshoot business logic errors.md
@@ -1,47 +1,16 @@
----
-title: "Troubleshooting with Lumigo"
-chapter: true
-weight: 12
----
++++
+title = "3.3 Troubleshoot business logic errors"
+chapter = true
+weight = 30
++++
 
-## Troubleshoot timeouts (requestUnicorn)
+## Troubleshoot business logic errors
 
-1. If you click on the `Timeout` issue for the `requestUnicorn` function, it will take you to the function details page for the function and show you the invocations that timed out.
+Lumigo is not just great at monitoring your production application and alerting you to problems. Turns out our customers also love using it for debugging business logic errors during development because they can easily peek into the internal state of their application - every invocation event, event environment variable that was used, and the request and response for every HTTP/TCP requests their functions make to other services!
 
-![requestUnicorn timeouts](/images/mod03-lumigo-requestUnicorn-timeouts.png)
+Let's see how we can use these information to help us debug a problem in our business logic.
 
-2. Click on one of the timed out transactions to see what happened in that transaction.
-
-![requestUnicorn timed out](/images/mod03-lumigo-requestUnicorn-timeout-transaction.png)
-
-3. From the function logs, you can see a message like `2020-10-20T11:40:37.402Z	3ea3b770-2986-4926-a0b3-2c6a045bfa20	INFO	Finding unicorn for  42.34963749150315 ,  -71.05718295574066`
-
-and then 6 seconds later, the invocation timed out.
-
-![requestUnicorn timed out](/images/mod03-lumigo-requestUnicorn-timeout-transaction-log.png)
-
-4. Click on the `Timeline` tab and you will see that the request to `4fsay0n12a.execute-api.us-east-1.amazonaws.com` never completed, hence the `N/A`. So this was the cause for the invocation timing out.
-
-![requestUnicorn timed out](/images/mod03-lumigo-requestUnicorn-timeout-transaction-timeline.png)
-
-
-## Troubleshoot timeouts (calcSalaries)
-
-1. Go to back the [Issues & Alerts](https://platform.lumigo.io/issues) page and you'll see that the `calcSalaries` function has also timed out a few times. As before, click on the `Timeout` issue for `calcSalaries` and see the timed out invocations.
-
-![calcSalaries timeouts](/images/mod03-lumigo-calcSalaries-timeouts.png)
-
-2. Click on one of the timed out transactions to see what happened.
-
-![calcSalaries timed out](/images/mod03-lumigo-calcSalaries-timeout-transaction.png)
-
-3. Unfortunately, there's nothing in the logs to indicate what happened. But let's click on `Timeline` tab to see what happened.
-
-![requestUnicorn timed out](/images/mod03-lumigo-requestUnicorn-timeout-transaction-timeline.png)
-
-## Troubleshoot business logic errors (uploadReceipt)
-
-1. Go to back the [Issues & Alerts](https://platform.lumigo.io/issues) page and you'll see that the `uploadReceipt` function has thrown a few `TypeError`. 
+1. Go to back the [Issues & Alerts](https://platform.lumigo.io/issues) page and you'll see that the `uploadReceipt` function has thrown a few `TypeError`.
 
 ![uploadReceipt errors](/images/mod03-lumigo-uploadReceipt.png)
 

--- a/content/03_module/_index.md
+++ b/content/03_module/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Module 3"
 chapter = true
-weight = 11
+weight = 30
 +++
 
 # Module 3: Troubleshooting with Lumigo
@@ -11,3 +11,5 @@ In this module, we'll use Lumigo to troubleshoot the issues in the demo app.
 If you go to the [Issues & Alerts](https://platform.lumigo.io/issues) page and you will see at a glance all the issues that Lumigo has identified in your environment.
 
 ![Lumigo issues](/images/mod03-lumigo-issues-and-alerts.png)
+
+{{% children showhidden="false" %}}

--- a/content/04_module/10-Debugging performance issues.md
+++ b/content/04_module/10-Debugging performance issues.md
@@ -1,0 +1,39 @@
++++
+title = "4.1 Debugging performance issues"
+chapter = true
+weight = 10
++++
+
+## Debugging performance issues
+
+1. Go to the [Dashboard page](https://platform.lumigo.io/dashboard), and have a look at the `Service Latency` widget at the bottom right. This shows you the tail latency for serivces that you are calling from your Lambda functions.
+
+![service latency](/images/mod04-lumigo-service-latency.png)
+
+2. By default, this widget is sorted by the `p95 (ms)` column. Somewhere amongst the top, you might see `4fsay0n12a.execute-api.us-east-1.amazonaws.com` up there, by either `p95 (ms)` or `p99 (ms)`.
+
+![slow dependency](/images/mod04-lumigo-slow-dependency.png)
+
+3. Click on the p99 latency value (4337 in my case)
+
+![click on the p99 value](/images/mod04-lumigo-p99.png)
+
+This takes you to the [Explore page](https://platform.lumigo.io/search) with a prefilled query that finds the transactions where this service was involved and recorded a latency that's equal to or greater than the latency value you clicked on.
+
+![find slow transactions](/images/mod04-lumigo-p99-transaction.png)
+
+4. Click on one of these transaction to see what happened.
+
+![slow transaction](/images/mod04-lumigo-slow-transactions.png)
+
+In this transaction, you can see that we made 3 calls to `4fsay0n12a.execute-api.us-east-1.amazonaws.com`.
+
+5. Click on the `Timeline` tab and you will see that one of the requests to `4fsay0n12a.execute-api.us-east-1.amazonaws.com` took 4345ms.
+
+![transaction timeline](/images/mod04-lumigo-slow-transaction-timeline.png)
+
+6. Click on the slow HTTP request, and see that the response was for `Rocinante`.
+
+![slow request](/images/mod04-lumigo-slow-request.png)
+
+7. Go back to the [Explore page](https://platform.lumigo.io/search) and find other transactions where `4fsay0n12a.execute-api.us-east-1.amazonaws.com` had been slow. See if you can spot any commonalities to these slow requests.

--- a/content/04_module/20-Identifying slow cold starts.md
+++ b/content/04_module/20-Identifying slow cold starts.md
@@ -1,42 +1,10 @@
----
-title: "Debugging Performance Issues"
-chapter: true
-weight: 13
----
++++
+title = "4.2 Identifying slow cold starts"
+chapter = true
+weight = 20
++++
 
-1. Go to the [Dashboard page](https://platform.lumigo.io/dashboard), and have a look at the `Service Latency` widget at the bottom right. This shows you the tail latency for serivces that you are calling from your Lambda functions.
-
-![service latency](/images/mod04-lumigo-service-latency.png)
-
-2. By default, this widget is sorted by the `p95 (ms)` column. Somewhere amongst the top, you might see `4fsay0n12a.execute-api.us-east-1.amazonaws.com` up there, by either `p95 (ms)` or `p99 (ms)`.
-
-![slow dependency](/images/mod04-lumigo-slow-dependency.png)
-
-3. Click on the p99 latency value (4337 in my case)
-
-![click on the p99 value](/images/mod04-lumigo-p99.png)
-
-This takes you to the [Explore page](https://platform.lumigo.io/search) with a prefilled query that finds the transactions where this service was involved and recorded a latency that's equal to or greater than the latency value you clicked on.
-
-![find slow transactions](/images/mod04-lumigo-p99-transaction.png)
-
-4. Click on one of these transaction to see what happened.
-
-![slow transaction](/images/mod04-lumigo-slow-transactions.png)
-
-In this transaction, you can see that we made 3 calls to `4fsay0n12a.execute-api.us-east-1.amazonaws.com`.
-
-5. Click on the `Timeline` tab and you will see that one of the requests to `4fsay0n12a.execute-api.us-east-1.amazonaws.com` took 4345ms.
-
-![transaction timeline](/images/mod04-lumigo-slow-transaction-timeline.png)
-
-6. Click on the slow HTTP request, and see that the response was for `Rocinante`.
-
-![slow request](/images/mod04-lumigo-slow-request.png)
-
-7. Go back to the [Explore page](https://platform.lumigo.io/search) and find other transactions where `4fsay0n12a.execute-api.us-east-1.amazonaws.com` had been slow. See if you can spot any commonalities to these slow requests.
-
-## What about cold starts?
+## Identifying slow cold starts
 
 Ah, yes, the dreaded Lambda cold starts! So often the cause of many performance concerns, especially for user-facing API functions.
 

--- a/content/04_module/_index.md
+++ b/content/04_module/_index.md
@@ -1,9 +1,11 @@
 +++
 title = "Module 4"
 chapter = true
-weight = 11
+weight = 40
 +++
 
 # Module 4: Debugging Performance Issues
 
 In this module, we'll see how you can identify slow dependencies and debug slow Lambda invocations.
+
+{{% children showhidden="false" %}}

--- a/content/05_module/05-alerting.md
+++ b/content/05_module/05-alerting.md
@@ -1,8 +1,10 @@
----
-title: "Alerting"
-chapter: true
-weight: 14
----
++++
+title = "5.1 Setting up alerts"
+chapter = true
+weight = 10
++++
+
+## Setting up alerts
 
 1. Go to the [Alerts](https://platform.lumigo.io/alerts-configurations) page, you can see that Lumigo has configured a couple of default alerts.
 

--- a/content/05_module/_index.md
+++ b/content/05_module/_index.md
@@ -1,9 +1,11 @@
 +++
 title = "Module 5"
 chapter = true
-weight = 11
+weight = 50
 +++
 
 # Module 5 - Alerting
 
 In this module, we'll set up alerts in Lumigo.
+
+{{% children showhidden="false" %}}

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,14 +8,35 @@ weight: 1
 
 ### Welcome
 
+Lumigo is a troubleshooting platform for serverless applications. With one-click distributed tracing, Lumigo lets developers effortlessly find & fix issues in serverless and microservices environments.
+
 In this workshop you will learn how easy it can be to debug serverless applications with Lumigo.
 
 ### Learning Objectives
+
 - Create and deploy a demo appolication.
 - Integrate Lumigo with the demo application and view your applicatio in Lumigo.
 - Use Lumigo to troubleshoot timeouts and business logic.
 - Identify slow dependencies and debug slow Lambda invocations.
-- Setting up alerts in lumigo
+- Setting up alerts in lumigo.
+
+### Who should take this workshop?
+
+- Software Developers
+- Infrastructure Engineers
+- DevOps Engineers
+- Solutions Architects
+- Site Reliability Engineers (SREs)
+- Technical leads
+
+### What we will cover in this workshop
+
+- Deploying a full-stack application using the [Serverless framework](https://www.serverless.com/open-source/).
+- One-click distributed tracing with Lumigo.
+- Troubleshooting Lambda timeout errors.
+- Troubleshooting errors in business logic.
+- Troubleshooting performance issues.
+- Configuring alerts in Lumigo.
 
 {{% notice warning %}}
 <p style='text-align: left;'>

--- a/content/conclusion/_index.md
+++ b/content/conclusion/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Conclusion"
+title: "Next Steps"
 chapter: true
 weight: 12
 ---
@@ -7,8 +7,6 @@ weight: 12
 # Next Steps
 
 I hope you have enjoyed these exercises and got a feel of how easy it can be to debug serverless applications with Lumigo.
-
-For a chance to win a XBox Series X and to try out Lumigo for real, please raise your hand and join one of our breakout rooms for a 1-2-1 session to help you integrate Lumigo with your production accounts to see what insights Lumigo can give you.
 
 There is a generous [free tier](https://lumigo.io/pricing) where you can trace up to 150,000 Lambda invocations a month for free.
 


### PR DESCRIPTION
*Description of changes:*

As discussed, this PR split module 2-5 so that each module is smaller lessons, and renames `Conclusions` to `Next Steps`. It also removes the mentions of X-Box from the `Next Steps`, which is no longer relevant.